### PR TITLE
Feature/initial admin password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ node_modules
 *.mo
 /.idea
 .vscode/
+
+AGENTS.md
+
+frontend/packages/*
+!frontend/packages/volto-procergs-sitebase
+
+backend/.mxdev_cache/
+backend/.venv/

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ PLONE_VERSION=$(shell cat backend/version.txt)
 BACKEND_ADD_PACKAGES ?=
 FRONTEND_ADD_PACKAGES ?=
 FRONTEND_ADD_ADDONS ?=
+FRONTEND_SET_THEME ?=
 FRONTEND_ADD_MRSDEVELOPER ?=
+FRONTEND_ADD_PNPM_WORKSPACE ?=
+
 
 # We like colors
 # From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects
@@ -49,10 +52,14 @@ help: ## This help message
 ###########################################
 .PHONY: frontend-install
 frontend-install:  ## Install React Frontend
+	# ADD_MRSDEVELOPER is single-quoted because its value is JSON containing double quotes.
+	# The other variables are simple comma-separated strings, so double quotes are fine.
 	$(MAKE) -C "./frontend/" install \
 		ADD_PACKAGES="$(FRONTEND_ADD_PACKAGES)" \
 		ADD_ADDONS="$(FRONTEND_ADD_ADDONS)" \
-		ADD_MRSDEVELOPER="$(FRONTEND_ADD_MRSDEVELOPER)"
+		SET_THEME="$(FRONTEND_SET_THEME)" \
+		ADD_MRSDEVELOPER='$(FRONTEND_ADD_MRSDEVELOPER)' \
+		ADD_PNPM_WORKSPACE="$(FRONTEND_ADD_PNPM_WORKSPACE)"
 
 .PHONY: frontend-build
 frontend-build:  ## Build React Frontend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,3 +42,5 @@ RUN <<EOT
     chgrp -R 0 /app
     chmod -R g=u /app
 EOT
+
+ENTRYPOINT ["/app/scripts/sitebase-entrypoint.sh"]

--- a/backend/scripts/sitebase-entrypoint.sh
+++ b/backend/scripts/sitebase-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Thin wrapper around the official Plone docker-entrypoint.sh.
+# Generates /app/inituser from $ADMIN_PASSWORD before delegating.
+# inituser is only relevant on the very first start of a new site (empty ZODB).
+# Zope ignores it once the admin user already exists in the database.
+#
+# Note: inituser uses SSHA (SHA1) because that is the only format Zope's
+# User Folder supports — this is a Zope constraint, not a choice.
+set -e
+
+if [ -n "$ADMIN_PASSWORD" ]; then
+    python3 - <<'EOF'
+import base64, hashlib, os, sys
+pw = os.environ["ADMIN_PASSWORD"]
+salt = os.urandom(8)
+digest = hashlib.sha1(pw.encode() + salt).digest()
+ssha = base64.b64encode(digest + salt).decode()
+path = "/app/inituser"
+# Create with 600 atomically — avoids a world-readable window between open() and chmod()
+fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(fd, "w") as f:
+    f.write("admin:{SSHA}" + ssha)
+print("sitebase-entrypoint: inituser generated from ADMIN_PASSWORD", file=sys.stderr)
+EOF
+    # Unset so the plaintext password is not visible in Zope's /proc/<pid>/environ
+    unset ADMIN_PASSWORD
+fi
+
+exec /app/docker-entrypoint.sh "$@"

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -10,6 +10,9 @@ MAKEFLAGS+=--no-builtin-rules
 
 CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
+# Load root-level frontend customization values when running directly from ./frontend.
+-include $(CURRENT_DIR)/../.env
+
 # Recipe snippets for reuse
 
 # We like colors
@@ -28,11 +31,19 @@ IMAGE_NAME=ghcr.io/PROCERGS/sitebase-frontend
 IMAGE_TAG=latest
 VOLTO_VERSION = $(shell cat ./mrs.developer.json | python -c "import sys, json; print(json.load(sys.stdin)['core']['tag'])")
 
-# Extra packages/addons to inject before pnpm install.
-# Passed from the root Makefile via .env (FRONTEND_ADD_PACKAGES / FRONTEND_ADD_ADDONS / FRONTEND_ADD_MRSDEVELOPER).
-ADD_PACKAGES ?=
-ADD_ADDONS ?=
-ADD_MRSDEVELOPER ?=
+# Frontend-prefixed customization variables as defined in ../.env.
+FRONTEND_ADD_PACKAGES ?=
+FRONTEND_ADD_ADDONS ?=
+FRONTEND_SET_THEME ?=
+FRONTEND_ADD_MRSDEVELOPER ?=
+FRONTEND_ADD_PNPM_WORKSPACE ?=
+
+# Effective variables consumed by scripts. These can still be overridden directly as ADD_*.
+ADD_PACKAGES ?= $(FRONTEND_ADD_PACKAGES)
+ADD_ADDONS ?= $(FRONTEND_ADD_ADDONS)
+SET_THEME ?= $(FRONTEND_SET_THEME)
+ADD_MRSDEVELOPER ?= $(FRONTEND_ADD_MRSDEVELOPER)
+ADD_PNPM_WORKSPACE ?= $(FRONTEND_ADD_PNPM_WORKSPACE)
 
 .PHONY: help
 help: ## Show this help
@@ -54,9 +65,17 @@ install: ## Installs the add-on in a development environment
 		echo "$(GREEN)==> Registering extra Volto addons$(RESET)"
 		bash $(CURRENT_DIR)/scripts/add_addons.sh "$(ADD_ADDONS)"
 	fi
+	if [ -n "$(SET_THEME)" ]; then
+		echo "$(GREEN)==> Setting Volto theme$(RESET)"
+		bash $(CURRENT_DIR)/scripts/set_theme.sh "$(SET_THEME)"
+	fi
 	if [ -n "$(ADD_MRSDEVELOPER)" ]; then
 		echo "$(GREEN)==> Merging mrs-developer entries$(RESET)"
-		bash $(CURRENT_DIR)/scripts/add_mrsdeveloper.sh "$(ADD_MRSDEVELOPER)"
+		bash $(CURRENT_DIR)/scripts/add_mrsdeveloper.sh '$(ADD_MRSDEVELOPER)'
+	fi
+	if [ -n "$(ADD_PNPM_WORKSPACE)" ]; then
+		echo "$(GREEN)==> Extending pnpm workspace$(RESET)"
+		bash $(CURRENT_DIR)/scripts/add_pnpm_workspace.sh "$(ADD_PNPM_WORKSPACE)"
 	fi
 	pnpm dlx mrs-developer missdev --no-config --fetch-https
 	pnpm i

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,6 +7,44 @@ settings:
 overrides:
   '@pmmmwh/react-refresh-webpack-plugin': ^0.5.15
   react-refresh: ^0.14.2
+  loader-utils: '>=2.0.3'
+  loader-utils@^1: '>=1.4.1'
+  loader-utils@^2: '>=2.0.3'
+  immer: '>=9.0.6'
+  immer@^8: '>=9.0.6'
+  form-data: '>=4.0.4'
+  form-data@^2: '>=2.5.4'
+  form-data@^3: '>=3.0.4'
+  form-data@^4: '>=4.0.4'
+  request>form-data: '>=2.5.4'
+  shell-quote: '>=1.7.3'
+  shell-quote@^1: '>=1.7.3'
+  basic-ftp: '>=5.2.0'
+  basic-ftp@^5: '>=5.2.0'
+  '@babel/traverse': '>=7.23.2'
+  qs: '>=6.14.1'
+  qs@^6: '>=6.14.1'
+  axios: '>=1.13.5'
+  axios@^0: '>=1.13.5'
+  axios@^1: '>=1.13.5'
+  tar: '>=7.5.7'
+  tar@^6: '>=7.5.7'
+  isomorphic-fetch>node-fetch: 2.7.0
+  node-fetch@^1: 2.7.0
+  nth-check@^1: 2.1.1
+  minimatch@3.0.4: 3.1.2
+  json5@^0: 1.0.2
+  braces@^2: 3.0.3
+  body-parser@^1: 1.20.3
+  http-proxy-middleware@^2: 2.0.9
+  path-to-regexp@^0.1: 0.1.12
+  cross-spawn: 7.0.5
+  browserslist@4.14.2: 4.25.1
+  '@babel/runtime@7.20.6': 7.26.10
+  prismjs@1.27.0: 1.30.0
+  tmp@0.2.1: 0.2.4
+  simple-git: '>=3.32.3'
+  simple-git@^3: '>=3.32.3'
 
 importers:
 
@@ -90,8 +128,8 @@ importers:
         specifier: ^5.59.0
         version: 5.71.5(react@18.2.0)
       axios:
-        specifier: ^1.8.2
-        version: 1.8.4(debug@4.3.4)
+        specifier: '>=1.13.5'
+        version: 1.17.0(debug@4.3.4)
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@8.1.1)
@@ -338,8 +376,8 @@ importers:
         specifier: 2.9.0
         version: 2.9.0
       cross-spawn:
-        specifier: 5.1.0
-        version: 5.1.0
+        specifier: 7.0.5
+        version: 7.0.5
       execa:
         specifier: 0.6.3
         version: 0.6.3
@@ -497,8 +535,8 @@ importers:
         specifier: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
         version: 18.2.0(react@18.2.0)
       tmp:
-        specifier: 0.2.1
-        version: 0.2.1
+        specifier: 0.2.4
+        version: 0.2.4
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.16.4
@@ -589,7 +627,7 @@ importers:
         version: 1.0.10
       wait-on:
         specifier: ^7.2.0
-        version: 7.2.0(debug@4.3.2)
+        version: 7.2.0
     devDependencies:
       release-it:
         specifier: ^16.1.3
@@ -831,8 +869,8 @@ importers:
         specifier: 3.3.2
         version: 3.3.2
       http-proxy-middleware:
-        specifier: 2.0.1
-        version: 2.0.1(debug@4.3.2)
+        specifier: 2.0.9
+        version: 2.0.9(@types/express@4.17.21)(debug@4.3.2)
       image-extensions:
         specifier: 1.1.0
         version: 1.1.0
@@ -876,8 +914,8 @@ importers:
         specifier: 5.3.0
         version: 5.3.0
       prismjs:
-        specifier: 1.27.0
-        version: 1.27.0
+        specifier: 1.30.0
+        version: 1.30.0
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -910,13 +948,13 @@ importers:
         version: 4.1.1(react@18.2.0)
       react-dates:
         specifier: 21.5.1
-        version: 21.5.1(@babel/runtime@7.20.6)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 21.5.1(@babel/runtime@7.26.10)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       react-detect-click-outside:
         specifier: 1.1.1
         version: 1.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-dnd:
         specifier: 5.0.0
-        version: 5.0.0(react@18.2.0)
+        version: 5.0.0(encoding@0.1.13)(react@18.2.0)
       react-dnd-html5-backend:
         specifier: 5.0.1
         version: 5.0.1
@@ -940,7 +978,7 @@ importers:
         version: 3.12.1(react@18.2.0)
       react-intl-redux:
         specifier: 2.3.0
-        version: 2.3.0(@babel/runtime@7.20.6)(prop-types@15.7.2)(react-intl@3.12.1(react@18.2.0))(react-redux@8.1.2(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1))(react@18.2.0)
+        version: 2.3.0(@babel/runtime@7.26.10)(prop-types@15.7.2)(react-intl@3.12.1(react@18.2.0))(react-redux@8.1.2(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1))(react@18.2.0)
       react-medium-image-zoom:
         specifier: 3.0.15
         version: 3.0.15(prop-types@15.7.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1078,8 +1116,8 @@ importers:
         specifier: 7.8.3
         version: 7.8.3(@babel/core@7.26.10)
       '@babel/runtime':
-        specifier: 7.20.6
-        version: 7.20.6
+        specifier: 7.26.10
+        version: 7.26.10
       '@babel/types':
         specifier: 7.20.5
         version: 7.20.5
@@ -1393,8 +1431,8 @@ importers:
         specifier: 5.3.6
         version: 5.3.6(esbuild@0.25.2)(webpack@5.90.1(esbuild@0.25.2))
       tmp:
-        specifier: 0.2.1
-        version: 0.2.1
+        specifier: 0.2.4
+        version: 0.2.4
       ts-jest:
         specifier: ^26.4.2
         version: 26.5.6(jest@26.6.3)(typescript@5.8.2)
@@ -1552,7 +1590,7 @@ importers:
     dependencies:
       '@plone-collective/volto-authomatic':
         specifier: ^2.0.1
-        version: 2.0.1(@plone/volto@18.23.0(@babel/runtime@7.27.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4))
+        version: 2.0.1(@plone/volto@18.23.0(@babel/runtime@7.27.0)(@popperjs/core@2.11.8)(@types/express@4.17.21)(@types/react-dom@18.2.12)(@types/react@18.2.27)(encoding@0.1.13)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4))
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2341,8 +2379,8 @@ packages:
     resolution: {integrity: sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.20.6':
-    resolution: {integrity: sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==}
+  '@babel/runtime@7.26.10':
+    resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.27.0':
@@ -2886,6 +2924,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@isaacs/string-locale-compare@1.1.0':
     resolution: {integrity: sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==}
@@ -4264,6 +4306,12 @@ packages:
     resolution: {integrity: sha512-2bRovzs0nJZFlCN3rXirE4gwxCn97JNjMmwpecqlbgV9WcxX7WRuIrgzx/X7Ib7MYRbyUTpBYE0s2x6AmZXnlg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
+
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
@@ -5605,10 +5653,6 @@ packages:
     resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
     engines: {node: '>=0.10.0'}
 
-  arr-flatten@1.1.0:
-    resolution: {integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==}
-    engines: {node: '>=0.10.0'}
-
   arr-union@3.1.0:
     resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
     engines: {node: '>=0.10.0'}
@@ -5783,14 +5827,8 @@ packages:
     resolution: {integrity: sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg==}
     engines: {node: '>=4'}
 
-  axios@0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
-
-  axios@0.24.0:
-    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
-
-  axios@1.8.4:
-    resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
+  axios@1.17.0:
+    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -5943,8 +5981,8 @@ packages:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
     engines: {node: '>=0.10.0'}
 
-  basic-ftp@5.0.5:
-    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
+  basic-ftp@6.0.1:
+    resolution: {integrity: sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==}
     engines: {node: '>=10.0.0'}
 
   batch@0.6.1:
@@ -5991,8 +6029,8 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  body-parser@1.20.2:
-    resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   bonjour-service@1.3.0:
@@ -6019,10 +6057,6 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
-  braces@2.3.2:
-    resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
-    engines: {node: '>=0.10.0'}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -6036,13 +6070,13 @@ packages:
   browser-process-hrtime@1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
 
-  browserslist@4.14.2:
-    resolution: {integrity: sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==}
+  browserslist@4.24.4:
+    resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  browserslist@4.24.4:
-    resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
+  browserslist@4.25.1:
+    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -6186,6 +6220,9 @@ packages:
   caniuse-lite@1.0.30001709:
     resolution: {integrity: sha512-NgL3vUTnDrPCZ3zTahp4fsugQ4dc7EKTSzwQDPEel6DMoMnfH2jhry9n2Zm8onbSR+f/QtKHFOA+iAQu4kbtWA==}
 
+  caniuse-lite@1.0.30001797:
+    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
+
   capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -6263,6 +6300,10 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -6685,19 +6726,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  cross-spawn@5.1.0:
-    resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
-
-  cross-spawn@6.0.6:
-    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
-    engines: {node: '>=4.8'}
-
-  cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+  cross-spawn@7.0.5:
+    resolution: {integrity: sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==}
     engines: {node: '>= 8'}
 
   crypto-random-string@2.0.0:
@@ -7325,6 +7355,9 @@ packages:
   electron-to-chromium@1.5.130:
     resolution: {integrity: sha512-Ou2u7L9j2XLZbhqzyX0jWDj6gA8D3jIfVzt4rikLf3cGBa0VdReuFimBKS9tQJA4+XpeCxj1NoWlfBXzbMa9IA==}
 
+  electron-to-chromium@1.5.370:
+    resolution: {integrity: sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==}
+
   emittery@0.7.2:
     resolution: {integrity: sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==}
     engines: {node: '>=10'}
@@ -7942,10 +7975,6 @@ packages:
     resolution: {integrity: sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==}
     engines: {node: '>= 0.4.0'}
 
-  fill-range@4.0.0:
-    resolution: {integrity: sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==}
-    engines: {node: '>=0.10.0'}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -8018,6 +8047,15 @@ packages:
       debug:
         optional: true
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -8058,20 +8096,12 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
-  form-data@2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
-    engines: {node: '>= 0.12'}
-
-  form-data@2.5.3:
-    resolution: {integrity: sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==}
-    engines: {node: '>= 0.12'}
-
-  form-data@3.0.3:
-    resolution: {integrity: sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==}
-    engines: {node: '>= 6'}
-
   form-data@4.0.2:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
@@ -8559,12 +8589,8 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-middleware@2.0.1:
-    resolution: {integrity: sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==}
-    engines: {node: '>=12.0.0'}
-
-  http-proxy-middleware@2.0.7:
-    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
+  http-proxy-middleware@2.0.9:
+    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -8666,9 +8692,6 @@ packages:
 
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
-
-  immer@8.0.1:
-    resolution: {integrity: sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==}
 
   immutable@3.8.2:
     resolution: {integrity: sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==}
@@ -9510,10 +9533,6 @@ packages:
   json3@3.3.3:
     resolution: {integrity: sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==}
 
-  json5@0.5.1:
-    resolution: {integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==}
-    hasBin: true
-
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -9958,10 +9977,6 @@ packages:
     resolution: {integrity: sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==}
     engines: {node: '>=4.0.0'}
 
-  loader-utils@2.0.0:
-    resolution: {integrity: sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==}
-    engines: {node: '>=8.9.0'}
-
   loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
@@ -10101,9 +10116,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@4.1.5:
-    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -10452,12 +10464,6 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@3.0.4:
-    resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
-
-  minimatch@3.0.8:
-    resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
-
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -10522,6 +10528,10 @@ packages:
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
@@ -10638,9 +10648,6 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  nice-try@1.0.5:
-    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
-
   nise@5.1.9:
     resolution: {integrity: sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==}
 
@@ -10660,9 +10667,6 @@ packages:
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
-
-  node-fetch@1.7.3:
-    resolution: {integrity: sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -10696,9 +10700,6 @@ packages:
 
   node-notifier@8.0.2:
     resolution: {integrity: sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==}
-
-  node-releases@1.1.77:
-    resolution: {integrity: sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -10822,9 +10823,6 @@ packages:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
-
-  nth-check@1.0.2:
-    resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -11164,8 +11162,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@0.1.7:
-    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@1.9.0:
     resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
@@ -11561,8 +11559,8 @@ packages:
     resolution: {integrity: sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==}
     engines: {node: '>=4'}
 
-  prismjs@1.27.0:
-    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
   proc-log@1.0.0:
@@ -11649,6 +11647,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
@@ -11656,9 +11658,6 @@ packages:
     resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
     engines: {node: '>= 0.10'}
     hasBin: true
-
-  pseudomap@1.0.2:
-    resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -11689,16 +11688,8 @@ packages:
 
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
-  qs@6.11.0:
-    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
-  qs@6.5.3:
-    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   query-string@7.1.0:
@@ -11823,7 +11814,7 @@ packages:
   react-dates@21.5.1:
     resolution: {integrity: sha512-1Lplx6T5U2Gu1vN1jh8Nrb+nyA5Uw7LdVVKGqjIoO9Kj6F3mU2budB6DlkxB5hAcjxk3KNzcSHPMYcWPUxvL0g==}
     peerDependencies:
-      '@babel/runtime': ^7.0.0
+      '@babel/runtime': 7.26.10
       moment: ^2.18.1
       react: ^0.14 || ^15.5.4 || ^16.1.1
       react-dom: ^0.14 || ^15.5.4 || ^16.1.1
@@ -11912,7 +11903,7 @@ packages:
   react-intl-redux@2.3.0:
     resolution: {integrity: sha512-lIAco0dlVIn8Dzc+epHpZZD8oM2TD62SJTkJ+x33KnvYB5l9ouLTvgz1ztajHuhiIBFq6n2mWwnS74Vim8CMuQ==}
     peerDependencies:
-      '@babel/runtime': ^7.17.9
+      '@babel/runtime': 7.26.10
       prop-types: ^15.8.1
       react: ^16.12.0 || ^17.0.2 || ^18.0.0
       react-intl: "^2.2.2 ||\_^3.0.0 || ^4.0.0 || ^5.0.0"
@@ -12103,13 +12094,13 @@ packages:
   react-with-styles-interface-css@6.0.0:
     resolution: {integrity: sha512-6khSG1Trf4L/uXOge/ZAlBnq2O2PEXlQEqAhCRbvzaQU4sksIkdwpCPEl6d+DtP3+IdhyffTWuHDO9lhe1iYvA==}
     peerDependencies:
-      '@babel/runtime': ^7.0.0
+      '@babel/runtime': 7.26.10
       react-with-styles: ^3.0.0 || ^4.0.0
 
   react-with-styles@4.2.0:
     resolution: {integrity: sha512-tZCTY27KriRNhwHIbg1NkSdTTOSfXDg6Z7s+Q37mtz0Ym7Sc7IOr3PzVt4qJhJMW6Nkvfi3g34FuhtiGAJCBQA==}
     peerDependencies:
-      '@babel/runtime': ^7.0.0
+      '@babel/runtime': 7.26.10
       react: '>=0.14'
       react-with-direction: ^1.3.1
 
@@ -12235,9 +12226,6 @@ packages:
   regenerator-runtime@0.11.1:
     resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
 
-  regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -12310,10 +12298,6 @@ packages:
 
   renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
-
-  repeat-element@1.1.4:
-    resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}
-    engines: {node: '>=0.10.0'}
 
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
@@ -12693,24 +12677,17 @@ packages:
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
-  shebang-command@1.2.0:
-    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
-    engines: {node: '>=0.10.0'}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
-
-  shebang-regex@1.0.0:
-    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
-    engines: {node: '>=0.10.0'}
 
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.7.2:
-    resolution: {integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
@@ -12751,8 +12728,8 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     hasBin: true
 
-  simple-git@3.27.0:
-    resolution: {integrity: sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==}
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -12826,14 +12803,6 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  snapdragon-node@2.1.1:
-    resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
-    engines: {node: '>=0.10.0'}
-
-  snapdragon-util@3.0.1:
-    resolution: {integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==}
-    engines: {node: '>=0.10.0'}
 
   snapdragon@0.8.2:
     resolution: {integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==}
@@ -13289,9 +13258,9 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+    engines: {node: '>=18'}
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -13455,12 +13424,8 @@ packages:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
 
-  tmp@0.2.1:
-    resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
-    engines: {node: '>=8.17.0'}
-
-  tmp@0.2.3:
-    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+  tmp@0.2.4:
+    resolution: {integrity: sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -13481,10 +13446,6 @@ packages:
   to-readable-stream@1.0.0:
     resolution: {integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==}
     engines: {node: '>=6'}
-
-  to-regex-range@2.1.1:
-    resolution: {integrity: sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==}
-    engines: {node: '>=0.10.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -14449,14 +14410,15 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yallist@2.1.2:
-    resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml-eslint-parser@1.3.0:
     resolution: {integrity: sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==}
@@ -15496,9 +15458,9 @@ snapshots:
       core-js-pure: 3.41.0
       regenerator-runtime: 0.14.1
 
-  '@babel/runtime@7.20.6':
+  '@babel/runtime@7.26.10':
     dependencies:
-      regenerator-runtime: 0.13.11
+      regenerator-runtime: 0.14.1
 
   '@babel/runtime@7.27.0':
     dependencies:
@@ -15566,14 +15528,14 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 4.0.2
+      form-data: 4.0.5
       http-signature: 1.4.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.14.0
+      qs: 6.15.2
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -15634,7 +15596,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.25.9
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -15661,7 +15623,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@18.2.27)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -15871,13 +15833,13 @@ snapshots:
 
   '@fluentui/react-component-event-listener@0.63.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
   '@fluentui/react-component-ref@0.63.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 16.13.1
@@ -15973,6 +15935,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
 
   '@isaacs/string-locale-compare@1.1.0': {}
 
@@ -16289,7 +16255,7 @@ snapshots:
 
   '@loadable/component@5.14.1(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
       react-is: 16.13.1
@@ -16338,7 +16304,7 @@ snapshots:
       '@rushstack/terminal': 0.10.0(@types/node@20.17.30)
       '@rushstack/ts-command-line': 4.19.1(@types/node@20.17.30)
       lodash: 4.17.21
-      minimatch: 3.0.8
+      minimatch: 3.1.2
       resolve: 1.22.10
       semver: 7.5.4
       source-map: 0.6.1
@@ -16357,7 +16323,7 @@ snapshots:
       '@rushstack/terminal': 0.10.0(@types/node@22.16.5)
       '@rushstack/ts-command-line': 4.19.1(@types/node@22.16.5)
       lodash: 4.17.21
-      minimatch: 3.0.8
+      minimatch: 3.1.2
       resolve: 1.22.10
       semver: 7.5.4
       source-map: 0.6.1
@@ -16846,9 +16812,9 @@ snapshots:
 
   '@pkgr/core@0.2.0': {}
 
-  '@plone-collective/volto-authomatic@2.0.1(@plone/volto@18.23.0(@babel/runtime@7.27.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4))':
+  '@plone-collective/volto-authomatic@2.0.1(@plone/volto@18.23.0(@babel/runtime@7.27.0)(@popperjs/core@2.11.8)(@types/express@4.17.21)(@types/react-dom@18.2.12)(@types/react@18.2.27)(encoding@0.1.13)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4))':
     dependencies:
-      '@plone/volto': 18.23.0(@babel/runtime@7.27.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4)
+      '@plone/volto': 18.23.0(@babel/runtime@7.27.0)(@popperjs/core@2.11.8)(@types/express@4.17.21)(@types/react-dom@18.2.12)(@types/react@18.2.27)(encoding@0.1.13)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4)
 
   '@plone/registry@2.5.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -16858,7 +16824,7 @@ snapshots:
       dependency-graph: 0.10.0
       glob: 10.4.5
       react: 18.2.0
-      tmp: 0.2.1
+      tmp: 0.2.4
     optionalDependencies:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -16940,7 +16906,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@plone/volto@18.23.0(@babel/runtime@7.27.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4)':
+  '@plone/volto@18.23.0(@babel/runtime@7.27.0)(@popperjs/core@2.11.8)(@types/express@4.17.21)(@types/react-dom@18.2.12)(@types/react@18.2.27)(encoding@0.1.13)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4)':
     dependencies:
       '@loadable/component': 5.14.1(react@18.2.0)
       '@loadable/server': 5.14.0(@loadable/component@5.14.1(react@18.2.0))(react@18.2.0)
@@ -16960,7 +16926,7 @@ snapshots:
       github-slugger: 1.4.0
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
-      http-proxy-middleware: 2.0.1(debug@4.3.2)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.3.2)
       image-extensions: 1.1.0
       immutable: 3.8.2
       is-hotkey: 0.2.0
@@ -16975,7 +16941,7 @@ snapshots:
       object-assign: 4.1.1
       prepend-http: 2.0.0
       pretty-bytes: 5.3.0
-      prismjs: 1.27.0
+      prismjs: 1.30.0
       process: 0.11.10
       promise-file-reader: 1.0.2
       prop-types: 15.7.2
@@ -16988,7 +16954,7 @@ snapshots:
       react-cookie: 4.1.1(react@18.2.0)
       react-dates: 21.5.1(@babel/runtime@7.27.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       react-detect-click-outside: 1.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react-dnd: 5.0.0(react@18.2.0)
+      react-dnd: 5.0.0(encoding@0.1.13)(react@18.2.0)
       react-dnd-html5-backend: 5.0.1
       react-dom: 18.2.0(react@18.2.0)
       react-dropzone: 11.1.0(react@18.2.0)
@@ -17037,10 +17003,12 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/runtime'
       - '@popperjs/core'
+      - '@types/express'
       - '@types/react'
       - '@types/react-dom'
       - bufferutil
       - canvas
+      - encoding
       - react-native
       - react-with-direction
       - seamless-immutable
@@ -18135,7 +18103,7 @@ snapshots:
 
   '@redux-devtools/extension@3.3.0(redux@4.2.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.10
       immutable: 4.3.7
       redux: 4.2.1
 
@@ -18312,6 +18280,12 @@ snapshots:
       tuf-js: 1.1.7
     transitivePeerDependencies:
       - supports-color
+
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -18747,14 +18721,14 @@ snapshots:
 
   '@testing-library/cypress@10.0.1(cypress@13.13.2)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@testing-library/dom': 9.3.4
       cypress: 13.13.2
 
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -18764,7 +18738,7 @@ snapshots:
 
   '@testing-library/dom@6.16.0':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@sheerun/mutationobserver-shim': 0.3.3
       '@types/testing-library__dom': 6.14.0
       aria-query: 4.2.2
@@ -18775,7 +18749,7 @@ snapshots:
   '@testing-library/dom@8.20.1':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -18786,7 +18760,7 @@ snapshots:
   '@testing-library/dom@9.3.4':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -18797,7 +18771,7 @@ snapshots:
   '@testing-library/jest-dom@5.16.5':
     dependencies:
       '@adobe/css-tools': 4.4.2
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@types/testing-library__jest-dom': 5.14.9
       aria-query: 5.3.2
       chalk: 3.0.0
@@ -18809,7 +18783,7 @@ snapshots:
   '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.14)(jest@26.6.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.16.5)(@vitest/ui@2.1.9)(jsdom@16.7.0)(less@3.11.1)(lightningcss@1.29.3)(sass@1.86.2)(terser@5.39.0))':
     dependencies:
       '@adobe/css-tools': 4.4.2
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       aria-query: 5.3.2
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -18825,7 +18799,7 @@ snapshots:
   '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.14)(vitest@2.1.9(@types/node@20.17.30)(@vitest/ui@2.1.9)(jsdom@22.1.0)(less@3.11.1)(lightningcss@1.29.3)(sass@1.86.2)(terser@5.39.0))':
     dependencies:
       '@adobe/css-tools': 4.4.2
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       aria-query: 5.3.2
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -18840,7 +18814,7 @@ snapshots:
   '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.14)(vitest@2.1.9(@types/node@22.16.5)(@vitest/ui@2.1.9)(jsdom@22.1.0)(less@3.11.1)(lightningcss@1.29.3)(sass@1.86.2)(terser@5.39.0))':
     dependencies:
       '@adobe/css-tools': 4.4.2
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       aria-query: 5.3.2
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -18855,7 +18829,7 @@ snapshots:
   '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.14)(vitest@3.2.4)':
     dependencies:
       '@adobe/css-tools': 4.4.2
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       aria-query: 5.3.2
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -18879,7 +18853,7 @@ snapshots:
 
   '@testing-library/react-hooks@8.0.1(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react-test-renderer@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       react: 18.2.0
       react-error-boundary: 3.1.4(react@18.2.0)
     optionalDependencies:
@@ -18889,7 +18863,7 @@ snapshots:
 
   '@testing-library/react@12.1.5(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@testing-library/dom': 8.20.1
       '@types/react-dom': 17.0.26(@types/react@18.2.27)
       react: 18.2.0
@@ -18899,7 +18873,7 @@ snapshots:
 
   '@testing-library/react@13.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@testing-library/dom': 8.20.1
       '@types/react-dom': 18.2.12
       react: 18.2.0
@@ -18907,7 +18881,7 @@ snapshots:
 
   '@testing-library/react@14.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@testing-library/dom': 9.3.4
       '@types/react-dom': 18.2.12
       react: 18.2.0
@@ -18915,7 +18889,7 @@ snapshots:
 
   '@testing-library/react@14.2.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@testing-library/dom': 9.3.4
       '@types/react-dom': 18.2.12
       react: 18.2.0
@@ -18923,7 +18897,7 @@ snapshots:
 
   '@testing-library/react@9.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@testing-library/dom': 6.16.0
       '@types/testing-library__react': 9.1.3
       react: 18.2.0
@@ -19260,7 +19234,7 @@ snapshots:
   '@types/vinyl@2.0.12':
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 20.17.30
+      '@types/node': 22.16.5
 
   '@types/ws@8.18.1':
     dependencies:
@@ -20073,7 +20047,7 @@ snapshots:
 
   aria-query@4.2.2:
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@babel/runtime-corejs3': 7.27.0
 
   aria-query@5.1.3:
@@ -20089,8 +20063,6 @@ snapshots:
   arity-n@1.0.4: {}
 
   arr-diff@4.0.0: {}
-
-  arr-flatten@1.1.0: {}
 
   arr-union@3.1.0: {}
 
@@ -20280,33 +20252,35 @@ snapshots:
 
   axe-core@4.8.4: {}
 
-  axios@0.21.4(debug@4.3.2):
+  axios@1.17.0:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.3.2)
+      follow-redirects: 1.16.0(debug@4.3.2)
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
-  axios@0.24.0(debug@4.3.2):
+  axios@1.17.0(debug@4.3.2):
     dependencies:
-      follow-redirects: 1.15.9(debug@4.3.2)
+      follow-redirects: 1.16.0(debug@4.3.2)
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
-  axios@1.8.4(debug@4.3.2):
+  axios@1.17.0(debug@4.3.4):
     dependencies:
-      follow-redirects: 1.15.9(debug@4.3.2)
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0(debug@4.3.4)
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
-
-  axios@1.8.4(debug@4.3.4):
-    dependencies:
-      follow-redirects: 1.15.9(debug@4.3.4)
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -20403,7 +20377,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
@@ -20507,7 +20481,7 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/preset-react': 7.26.3(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       babel-plugin-syntax-jsx: 6.18.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
       chalk: 4.1.2
@@ -20529,7 +20503,7 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/preset-react': 7.26.3(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       babel-plugin-syntax-jsx: 6.18.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
       chalk: 4.1.2
@@ -20552,7 +20526,7 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/preset-react': 7.26.3(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
     transitivePeerDependencies:
@@ -20614,7 +20588,7 @@ snapshots:
       mixin-deep: 1.3.2
       pascalcase: 0.1.1
 
-  basic-ftp@5.0.5: {}
+  basic-ftp@6.0.1: {}
 
   batch@0.6.1: {}
 
@@ -20661,7 +20635,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@1.20.2:
+  body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -20671,7 +20645,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.11.0
+      qs: 6.15.2
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -20720,21 +20694,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  braces@2.3.2:
-    dependencies:
-      arr-flatten: 1.1.0
-      array-unique: 0.3.2
-      extend-shallow: 2.0.1
-      fill-range: 4.0.0
-      isobject: 3.0.1
-      repeat-element: 1.1.4
-      snapdragon: 0.8.2
-      snapdragon-node: 2.1.1
-      split-string: 3.1.0
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -20745,19 +20704,19 @@ snapshots:
 
   browser-process-hrtime@1.0.0: {}
 
-  browserslist@4.14.2:
-    dependencies:
-      caniuse-lite: 1.0.30001709
-      electron-to-chromium: 1.5.130
-      escalade: 3.2.0
-      node-releases: 1.1.77
-
   browserslist@4.24.4:
     dependencies:
       caniuse-lite: 1.0.30001709
       electron-to-chromium: 1.5.130
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.4)
+
+  browserslist@4.25.1:
+    dependencies:
+      caniuse-lite: 1.0.30001797
+      electron-to-chromium: 1.5.370
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
   bs-logger@0.2.6:
     dependencies:
@@ -20800,7 +20759,7 @@ snapshots:
 
   bundlewatch@0.3.3(debug@4.3.2):
     dependencies:
-      axios: 0.24.0(debug@4.3.2)
+      axios: 1.17.0(debug@4.3.2)
       bytes: 3.1.2
       chalk: 4.1.2
       ci-env: 1.17.0
@@ -20812,6 +20771,7 @@ snapshots:
       read-pkg-up: 7.0.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   bytes@3.1.2: {}
 
@@ -20858,7 +20818,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.2.1
+      tar: 7.5.16
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -20881,7 +20841,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 9.0.1
-      tar: 6.2.1
+      tar: 7.5.16
       unique-filename: 2.0.1
     transitivePeerDependencies:
       - bluebird
@@ -20898,7 +20858,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 4.0.0
       ssri: 10.0.6
-      tar: 6.2.1
+      tar: 7.5.16
       unique-filename: 3.0.0
 
   cache-base@1.0.1:
@@ -20984,12 +20944,14 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.24.4
+      browserslist: 4.25.1
       caniuse-lite: 1.0.30001709
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001709: {}
+
+  caniuse-lite@1.0.30001797: {}
 
   capture-exit@2.0.0:
     dependencies:
@@ -21068,6 +21030,8 @@ snapshots:
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -21466,27 +21430,7 @@ snapshots:
       minimist: 1.2.8
       request: 2.88.2
 
-  cross-spawn@5.1.0:
-    dependencies:
-      lru-cache: 4.1.5
-      shebang-command: 1.2.0
-      which: 1.3.1
-
-  cross-spawn@6.0.6:
-    dependencies:
-      nice-try: 1.0.5
-      path-key: 2.0.1
-      semver: 5.7.2
-      shebang-command: 1.2.0
-      which: 1.3.1
-
-  cross-spawn@7.0.3:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
-  cross-spawn@7.0.6:
+  cross-spawn@7.0.5:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -21569,7 +21513,7 @@ snapshots:
       boolbase: 1.0.0
       css-what: 3.4.2
       domutils: 1.7.0
-      nth-check: 1.0.2
+      nth-check: 2.1.1
 
   css-select@4.3.0:
     dependencies:
@@ -21754,7 +21698,7 @@ snapshots:
       request-progress: 3.0.0
       semver: 7.7.1
       supports-color: 8.1.1
-      tmp: 0.2.3
+      tmp: 0.2.4
       untildify: 4.0.0
       yauzl: 2.10.0
 
@@ -22069,7 +22013,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       csstype: 3.1.3
 
   dom-serializer@0.2.2:
@@ -22172,6 +22116,8 @@ snapshots:
 
   electron-to-chromium@1.5.130: {}
 
+  electron-to-chromium@1.5.370: {}
+
   emittery@0.7.2: {}
 
   emoji-regex@10.4.0: {}
@@ -22189,6 +22135,7 @@ snapshots:
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
+    optional: true
 
   end-of-stream@1.4.4:
     dependencies:
@@ -22499,7 +22446,7 @@ snapshots:
       babel-plugin-root-import: 6.1.0
       eslint-import-resolver-node: 0.2.3
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
-      json5: 0.5.1
+      json5: 1.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -22734,7 +22681,7 @@ snapshots:
       '@ungap/structured-clone': 1.3.0
       ajv: 6.12.6
       chalk: 4.1.2
-      cross-spawn: 7.0.6
+      cross-spawn: 7.0.5
       debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
@@ -22831,7 +22778,7 @@ snapshots:
 
   execa@0.6.3:
     dependencies:
-      cross-spawn: 5.1.0
+      cross-spawn: 7.0.5
       get-stream: 3.0.0
       is-stream: 1.1.0
       npm-run-path: 2.0.2
@@ -22841,7 +22788,7 @@ snapshots:
 
   execa@1.0.0:
     dependencies:
-      cross-spawn: 6.0.6
+      cross-spawn: 7.0.5
       get-stream: 4.1.0
       is-stream: 1.1.0
       npm-run-path: 2.0.2
@@ -22851,7 +22798,7 @@ snapshots:
 
   execa@4.1.0:
     dependencies:
-      cross-spawn: 7.0.6
+      cross-spawn: 7.0.5
       get-stream: 5.2.0
       human-signals: 1.1.1
       is-stream: 2.0.1
@@ -22863,7 +22810,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.6
+      cross-spawn: 7.0.5
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -22875,7 +22822,7 @@ snapshots:
 
   execa@7.2.0:
     dependencies:
-      cross-spawn: 7.0.6
+      cross-spawn: 7.0.5
       get-stream: 6.0.1
       human-signals: 4.3.1
       is-stream: 3.0.0
@@ -22887,7 +22834,7 @@ snapshots:
 
   execa@8.0.1:
     dependencies:
-      cross-spawn: 7.0.6
+      cross-spawn: 7.0.5
       get-stream: 8.0.1
       human-signals: 5.0.0
       is-stream: 3.0.0
@@ -22942,7 +22889,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.2
+      body-parser: 1.20.3
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.6.0
@@ -22959,9 +22906,9 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.7
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.11.0
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.18.0
@@ -23056,15 +23003,17 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fbjs@0.8.18:
+  fbjs@0.8.18(encoding@0.1.13):
     dependencies:
       core-js: 1.2.7
-      isomorphic-fetch: 2.2.1
+      isomorphic-fetch: 2.2.1(encoding@0.1.13)
       loose-envify: 1.4.0
       object-assign: 4.1.1
       promise: 7.1.1
       setimmediate: 1.0.5
       ua-parser-js: 0.7.40
+    transitivePeerDependencies:
+      - encoding
 
   fd-slicer@1.1.0:
     dependencies:
@@ -23121,13 +23070,6 @@ snapshots:
   filesize@6.1.0: {}
 
   filesize@6.4.0: {}
-
-  fill-range@4.0.0:
-    dependencies:
-      extend-shallow: 2.0.1
-      is-number: 3.0.0
-      repeat-string: 1.6.1
-      to-regex-range: 2.1.1
 
   fill-range@7.1.1:
     dependencies:
@@ -23210,7 +23152,11 @@ snapshots:
     optionalDependencies:
       debug: 4.3.2
 
-  follow-redirects@1.15.9(debug@4.3.4):
+  follow-redirects@1.16.0(debug@4.3.2):
+    optionalDependencies:
+      debug: 4.3.2
+
+  follow-redirects@1.16.0(debug@4.3.4):
     optionalDependencies:
       debug: 4.3.4(supports-color@8.1.1)
 
@@ -23222,7 +23168,7 @@ snapshots:
 
   foreground-child@3.3.1:
     dependencies:
-      cross-spawn: 7.0.6
+      cross-spawn: 7.0.5
       signal-exit: 4.1.0
 
   forever-agent@0.6.1: {}
@@ -23263,32 +23209,19 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
-  form-data@2.3.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-
-  form-data@2.5.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      mime-types: 2.1.35
-      safe-buffer: 5.2.1
-
-  form-data@3.0.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      mime-types: 2.1.35
-
   form-data@4.0.2:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
@@ -23454,7 +23387,7 @@ snapshots:
 
   get-uri@6.0.4:
     dependencies:
-      basic-ftp: 5.0.5
+      basic-ftp: 6.0.1
       data-uri-to-buffer: 6.0.2
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -23497,10 +23430,11 @@ snapshots:
 
   gitly@2.0.3:
     dependencies:
-      axios: 0.21.4(debug@4.3.2)
-      tar: 6.2.1
+      axios: 1.17.0
+      tar: 7.5.16
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   glob-parent@5.1.2:
     dependencies:
@@ -23751,7 +23685,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -23871,17 +23805,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.1(debug@4.3.2):
-    dependencies:
-      '@types/http-proxy': 1.17.16
-      http-proxy: 1.18.1(debug@4.3.2)
-      is-glob: 4.0.3
-      is-plain-obj: 3.0.0
-      micromatch: 4.0.8
-    transitivePeerDependencies:
-      - debug
-
-  http-proxy-middleware@2.0.7(@types/express@4.17.21)(debug@4.3.2):
+  http-proxy-middleware@2.0.9(@types/express@4.17.21)(debug@4.3.2):
     dependencies:
       '@types/http-proxy': 1.17.16
       http-proxy: 1.18.1(debug@4.3.2)
@@ -23986,8 +23910,6 @@ snapshots:
     optional: true
 
   immer@10.1.1: {}
-
-  immer@8.0.1: {}
 
   immutable@3.8.2: {}
 
@@ -24434,10 +24356,12 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-fetch@2.2.1:
+  isomorphic-fetch@2.2.1(encoding@0.1.13):
     dependencies:
-      node-fetch: 1.7.3
+      node-fetch: 2.7.0(encoding@0.1.13)
       whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
 
   isstream@0.1.2: {}
 
@@ -24633,7 +24557,7 @@ snapshots:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 20.17.30
+      '@types/node': 22.16.5
       jest-mock: 26.6.2
       jest-util: 26.6.2
 
@@ -25038,7 +24962,7 @@ snapshots:
       decimal.js: 10.5.0
       domexception: 2.0.1
       escodegen: 2.1.0
-      form-data: 3.0.3
+      form-data: 4.0.2
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -25071,7 +24995,7 @@ snapshots:
       decimal.js: 10.5.0
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.2
+      form-data: 4.0.5
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
@@ -25101,7 +25025,7 @@ snapshots:
       data-urls: 4.0.0
       decimal.js: 10.5.0
       domexception: 4.0.0
-      form-data: 4.0.2
+      form-data: 4.0.5
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
@@ -25151,8 +25075,6 @@ snapshots:
   json-stringify-safe@5.0.1: {}
 
   json3@3.3.3: {}
-
-  json5@0.5.1: {}
 
   json5@1.0.2:
     dependencies:
@@ -25531,12 +25453,6 @@ snapshots:
       emojis-list: 3.0.0
       json5: 1.0.2
 
-  loader-utils@2.0.0:
-    dependencies:
-      big.js: 5.2.2
-      emojis-list: 3.0.0
-      json5: 2.2.3
-
   loader-utils@2.0.4:
     dependencies:
       big.js: 5.2.2
@@ -25654,11 +25570,6 @@ snapshots:
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@4.1.5:
-    dependencies:
-      pseudomap: 1.0.2
-      yallist: 2.1.2
 
   lru-cache@5.1.1:
     dependencies:
@@ -26150,7 +26061,7 @@ snapshots:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
-      braces: 2.3.2
+      braces: 3.0.3
       define-property: 2.0.2
       extend-shallow: 3.0.2
       extglob: 2.0.4
@@ -26197,7 +26108,7 @@ snapshots:
 
   mini-create-react-context@0.4.1(prop-types@15.7.2)(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       prop-types: 15.7.2
       react: 18.2.0
       tiny-warning: 1.0.3
@@ -26208,14 +26119,6 @@ snapshots:
       webpack: 5.90.1(esbuild@0.25.2)
 
   minimalistic-assert@1.0.1: {}
-
-  minimatch@3.0.4:
-    dependencies:
-      brace-expansion: 1.1.11
-
-  minimatch@3.0.8:
-    dependencies:
-      brace-expansion: 1.1.11
 
   minimatch@3.1.2:
     dependencies:
@@ -26293,6 +26196,10 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.2
+
   mixin-deep@1.3.2:
     dependencies:
       for-in: 1.0.2
@@ -26340,7 +26247,7 @@ snapshots:
     dependencies:
       async: 3.2.6
       chalk: 2.4.2
-      simple-git: 3.27.0
+      simple-git: 3.36.0
     transitivePeerDependencies:
       - supports-color
 
@@ -26417,8 +26324,6 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  nice-try@1.0.5: {}
-
   nise@5.1.9:
     dependencies:
       '@sinonjs/commons': 3.0.1
@@ -26446,11 +26351,6 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
-  node-fetch@1.7.3:
-    dependencies:
-      encoding: 0.1.13
-      is-stream: 1.1.0
-
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -26475,7 +26375,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.7.1
-      tar: 6.2.1
+      tar: 7.5.16
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -26492,7 +26392,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.7.1
-      tar: 6.2.1
+      tar: 7.5.16
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -26509,8 +26409,6 @@ snapshots:
       uuid: 8.3.2
       which: 2.0.2
     optional: true
-
-  node-releases@1.1.77: {}
 
   node-releases@2.0.19: {}
 
@@ -26659,10 +26557,6 @@ snapshots:
       console-control-strings: 1.1.0
       gauge: 4.0.4
       set-blocking: 2.0.0
-
-  nth-check@1.0.2:
-    dependencies:
-      boolbase: 1.0.0
 
   nth-check@2.1.1:
     dependencies:
@@ -26990,7 +26884,7 @@ snapshots:
       read-package-json-fast: 2.0.3
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.2.1
+      tar: 7.5.16
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -27014,7 +26908,7 @@ snapshots:
       read-package-json-fast: 3.0.2
       sigstore: 1.9.0
       ssri: 10.0.6
-      tar: 6.2.1
+      tar: 7.5.16
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -27098,7 +26992,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-to-regexp@0.1.7: {}
+  path-to-regexp@0.1.12: {}
 
   path-to-regexp@1.9.0:
     dependencies:
@@ -27160,7 +27054,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
 
   posix-character-classes@0.1.1: {}
 
@@ -27174,7 +27068,7 @@ snapshots:
 
   postcss-colormin@4.0.3:
     dependencies:
-      browserslist: 4.24.4
+      browserslist: 4.25.1
       color: 3.2.1
       has: 1.0.4
       postcss: 7.0.39
@@ -27251,7 +27145,7 @@ snapshots:
 
   postcss-merge-rules@4.0.3:
     dependencies:
-      browserslist: 4.24.4
+      browserslist: 4.25.1
       caniuse-api: 3.0.0
       cssnano-util-same-parent: 4.0.1
       postcss: 7.0.39
@@ -27273,7 +27167,7 @@ snapshots:
   postcss-minify-params@4.0.2:
     dependencies:
       alphanum-sort: 1.0.2
-      browserslist: 4.24.4
+      browserslist: 4.25.1
       cssnano-util-get-arguments: 4.0.0
       postcss: 7.0.39
       postcss-value-parser: 3.3.1
@@ -27366,7 +27260,7 @@ snapshots:
 
   postcss-normalize-unicode@4.0.1:
     dependencies:
-      browserslist: 4.24.4
+      browserslist: 4.25.1
       postcss: 7.0.39
       postcss-value-parser: 3.3.1
 
@@ -27394,7 +27288,7 @@ snapshots:
 
   postcss-reduce-initial@4.0.3:
     dependencies:
-      browserslist: 4.24.4
+      browserslist: 4.25.1
       caniuse-api: 3.0.0
       has: 1.0.4
       postcss: 7.0.39
@@ -27540,7 +27434,7 @@ snapshots:
 
   pretty-time@1.1.0: {}
 
-  prismjs@1.27.0: {}
+  prismjs@1.30.0: {}
 
   proc-log@1.0.0: {}
 
@@ -27646,14 +27540,14 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   prr@1.0.1:
     optional: true
 
   ps-tree@1.2.0:
     dependencies:
       event-stream: 3.3.4
-
-  pseudomap@1.0.2: {}
 
   psl@1.15.0:
     dependencies:
@@ -27678,15 +27572,9 @@ snapshots:
 
   q@1.5.1: {}
 
-  qs@6.11.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
-
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.5.3: {}
 
   query-string@7.1.0:
     dependencies:
@@ -27985,7 +27873,7 @@ snapshots:
 
   react-beautiful-dnd@13.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       css-box-model: 1.2.1
       memoize-one: 5.2.1
       raf-schd: 4.0.3
@@ -28004,9 +27892,9 @@ snapshots:
       react: 18.2.0
       universal-cookie: 4.0.4
 
-  react-dates@21.5.1(@babel/runtime@7.20.6)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0):
+  react-dates@21.5.1(@babel/runtime@7.26.10)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       airbnb-prop-types: 2.16.0(react@18.2.0)
       consolidated-events: 2.0.2
       enzyme-shallow-equal: 1.0.7
@@ -28023,8 +27911,8 @@ snapshots:
       react-outside-click-handler: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-portal: 4.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-with-direction: 1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react-with-styles: 4.2.0(@babel/runtime@7.20.6)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
-      react-with-styles-interface-css: 6.0.0(@babel/runtime@7.20.6)(react-with-styles@4.2.0(@babel/runtime@7.20.6)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0))
+      react-with-styles: 4.2.0(@babel/runtime@7.26.10)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      react-with-styles-interface-css: 6.0.0(@babel/runtime@7.26.10)(react-with-styles@4.2.0(@babel/runtime@7.26.10)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0))
 
   react-dates@21.5.1(@babel/runtime@7.27.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -28057,9 +27945,9 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.10.4
       address: 1.1.2
-      browserslist: 4.14.2
+      browserslist: 4.25.1
       chalk: 2.4.2
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.5
       detect-port-alt: 1.1.6
       escape-string-regexp: 2.0.0
       filesize: 6.1.0
@@ -28068,15 +27956,15 @@ snapshots:
       global-modules: 2.0.0
       globby: 11.0.1
       gzip-size: 5.1.1
-      immer: 8.0.1
+      immer: 10.1.1
       is-root: 2.1.0
-      loader-utils: 2.0.0
+      loader-utils: 2.0.4
       open: 7.4.2
       pkg-up: 3.1.0
       prompts: 2.4.0
       react-error-overlay: 6.0.9
       recursive-readdir: 2.2.2
-      shell-quote: 1.7.2
+      shell-quote: 1.8.4
       strip-ansi: 6.0.0
       text-table: 0.2.0
       webpack: 5.90.1(esbuild@0.25.2)
@@ -28094,15 +27982,17 @@ snapshots:
       lodash: 4.17.21
       shallowequal: 1.1.0
 
-  react-dnd@5.0.0(react@18.2.0):
+  react-dnd@5.0.0(encoding@0.1.13)(react@18.2.0):
     dependencies:
       dnd-core: 4.0.5
       hoist-non-react-statics: 2.5.5
       invariant: 2.2.4
       lodash: 4.17.21
       react: 18.2.0
-      recompose: 0.27.1(react@18.2.0)
+      recompose: 0.27.1(encoding@0.1.13)(react@18.2.0)
       shallowequal: 1.1.0
+    transitivePeerDependencies:
+      - encoding
 
   react-docgen-typescript-plugin@1.0.8(typescript@5.8.2)(webpack@5.90.1(esbuild@0.25.2)):
     dependencies:
@@ -28151,7 +28041,7 @@ snapshots:
 
   react-error-boundary@3.1.4(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       react: 18.2.0
 
   react-error-overlay@6.0.9: {}
@@ -28173,9 +28063,9 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-intl-redux@2.3.0(@babel/runtime@7.20.6)(prop-types@15.7.2)(react-intl@3.12.1(react@18.2.0))(react-redux@8.1.2(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1))(react@18.2.0):
+  react-intl-redux@2.3.0(@babel/runtime@7.26.10)(prop-types@15.7.2)(react-intl@3.12.1(react@18.2.0))(react-redux@8.1.2(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       prop-types: 15.7.2
       react: 18.2.0
       react-intl: 3.12.1(react@18.2.0)
@@ -28254,7 +28144,7 @@ snapshots:
 
   react-redux@7.2.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@types/react-redux': 7.1.34
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -28266,7 +28156,7 @@ snapshots:
 
   react-redux@8.1.2(@types/react-dom@18.2.12)(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@types/hoist-non-react-statics': 3.3.6
       '@types/use-sync-external-store': 0.0.3
       hoist-non-react-statics: 3.3.2
@@ -28283,13 +28173,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       react: 18.2.0
       react-router: 5.2.0(react@18.2.0)
 
   react-router-dom@5.2.0(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.7.2
@@ -28306,7 +28196,7 @@ snapshots:
 
   react-router@5.2.0(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -28320,7 +28210,7 @@ snapshots:
 
   react-select-async-paginate@0.5.3(react-dom@18.2.0(react@18.2.0))(react-select@4.3.1(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@seznam/compose-react-refs': 1.0.6
       react: 18.2.0
       react-is-mounted-hook: 1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -28331,7 +28221,7 @@ snapshots:
 
   react-select@4.3.1(@types/react@18.2.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(@types/react@18.2.27)(react@18.2.0)
       memoize-one: 5.2.1
@@ -28361,7 +28251,7 @@ snapshots:
 
   react-sortable-hoc@2.0.0(prop-types@15.7.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       invariant: 2.2.4
       prop-types: 15.7.2
       react: 18.2.0
@@ -28406,7 +28296,7 @@ snapshots:
 
   react-toastify@5.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       classnames: 2.5.1
       prop-types: 15.7.2
       react: 18.2.0
@@ -28415,7 +28305,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.7.2
@@ -28424,7 +28314,7 @@ snapshots:
 
   react-virtualized@9.22.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       clsx: 1.2.1
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
@@ -28446,12 +28336,12 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-with-styles-interface-css@6.0.0(@babel/runtime@7.20.6)(react-with-styles@4.2.0(@babel/runtime@7.20.6)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)):
+  react-with-styles-interface-css@6.0.0(@babel/runtime@7.26.10)(react-with-styles@4.2.0(@babel/runtime@7.26.10)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       array.prototype.flat: 1.3.3
       global-cache: 1.2.1
-      react-with-styles: 4.2.0(@babel/runtime@7.20.6)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      react-with-styles: 4.2.0(@babel/runtime@7.26.10)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
 
   react-with-styles-interface-css@6.0.0(@babel/runtime@7.27.0)(react-with-styles@4.2.0(@babel/runtime@7.27.0)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)):
     dependencies:
@@ -28460,9 +28350,9 @@ snapshots:
       global-cache: 1.2.1
       react-with-styles: 4.2.0(@babel/runtime@7.27.0)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
 
-  react-with-styles@4.2.0(@babel/runtime@7.20.6)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0):
+  react-with-styles@4.2.0(@babel/runtime@7.26.10)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       airbnb-prop-types: 2.16.0(react@18.2.0)
       hoist-non-react-statics: 3.3.2
       object.assign: 4.1.7
@@ -28565,19 +28455,21 @@ snapshots:
     dependencies:
       resolve: 1.22.10
 
-  recompose@0.27.1(react@18.2.0):
+  recompose@0.27.1(encoding@0.1.13)(react@18.2.0):
     dependencies:
       babel-runtime: 6.26.0
       change-emitter: 0.1.6
-      fbjs: 0.8.18
+      fbjs: 0.8.18(encoding@0.1.13)
       hoist-non-react-statics: 2.5.5
       react: 18.2.0
       react-lifecycles-compat: 3.0.4
       symbol-observable: 1.2.0
+    transitivePeerDependencies:
+      - encoding
 
   recursive-readdir@2.2.2:
     dependencies:
-      minimatch: 3.0.4
+      minimatch: 3.1.2
 
   recursive-readdir@2.2.3:
     dependencies:
@@ -28619,7 +28511,7 @@ snapshots:
 
   redux@4.2.1:
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -28640,13 +28532,11 @@ snapshots:
 
   regenerator-runtime@0.11.1: {}
 
-  regenerator-runtime@0.13.11: {}
-
   regenerator-runtime@0.14.1: {}
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
 
   regex-not@1.0.2:
     dependencies:
@@ -28800,8 +28690,6 @@ snapshots:
       lodash: 4.17.21
       strip-ansi: 6.0.1
 
-  repeat-element@1.1.4: {}
-
   repeat-string@1.6.1: {}
 
   replace-ext@1.0.1: {}
@@ -28818,7 +28706,7 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 2.3.3
+      form-data: 4.0.2
       har-validator: 5.1.5
       http-signature: 1.2.0
       is-typedarray: 1.0.0
@@ -28827,7 +28715,7 @@ snapshots:
       mime-types: 2.1.35
       oauth-sign: 0.9.0
       performance-now: 2.1.0
-      qs: 6.5.3
+      qs: 6.15.2
       safe-buffer: 5.2.1
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
@@ -29123,7 +29011,7 @@ snapshots:
 
   semantic-ui-react@2.1.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       '@fluentui/react-component-event-listener': 0.63.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@fluentui/react-component-ref': 0.63.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@popperjs/core': 2.11.8
@@ -29257,19 +29145,13 @@ snapshots:
 
   shallowequal@1.1.0: {}
 
-  shebang-command@1.2.0:
-    dependencies:
-      shebang-regex: 1.0.0
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
-  shebang-regex@1.0.0: {}
-
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.7.2: {}
+  shell-quote@1.8.4: {}
 
   shelljs@0.8.5:
     dependencies:
@@ -29324,11 +29206,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  simple-git@3.27.0:
+  simple-git@3.36.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.0
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -29417,16 +29301,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
 
   smart-buffer@4.2.0: {}
-
-  snapdragon-node@2.1.1:
-    dependencies:
-      define-property: 1.0.0
-      isobject: 3.0.1
-      snapdragon-util: 3.0.1
-
-  snapdragon-util@3.0.1:
-    dependencies:
-      kind-of: 3.2.2
 
   snapdragon@0.8.2:
     dependencies:
@@ -29828,7 +29702,7 @@ snapshots:
 
   stylehacks@4.0.3:
     dependencies:
-      browserslist: 4.24.4
+      browserslist: 4.25.1
       postcss: 7.0.39
       postcss-selector-parser: 3.1.2
 
@@ -29911,11 +29785,11 @@ snapshots:
       cookiejar: 2.1.4
       debug: 3.2.7(supports-color@8.1.1)
       extend: 3.0.2
-      form-data: 2.5.3
+      form-data: 4.0.2
       formidable: 1.2.6
       methods: 1.1.2
       mime: 1.6.0
-      qs: 6.14.0
+      qs: 6.15.2
       readable-stream: 2.3.8
     transitivePeerDependencies:
       - supports-color
@@ -30016,14 +29890,13 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  tar@6.2.1:
+  tar@7.5.16:
     dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   temp-dir@2.0.0: {}
 
@@ -30165,11 +30038,7 @@ snapshots:
     dependencies:
       os-tmpdir: 1.0.2
 
-  tmp@0.2.1:
-    dependencies:
-      rimraf: 3.0.2
-
-  tmp@0.2.3: {}
+  tmp@0.2.4: {}
 
   tmpl@1.0.5: {}
 
@@ -30182,11 +30051,6 @@ snapshots:
       kind-of: 3.2.2
 
   to-readable-stream@1.0.0: {}
-
-  to-regex-range@2.1.1:
-    dependencies:
-      is-number: 3.0.0
-      repeat-string: 1.6.1
 
   to-regex-range@5.0.1:
     dependencies:
@@ -30611,6 +30475,12 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.1.3(browserslist@4.25.1):
+    dependencies:
+      browserslist: 4.25.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   update-notifier@5.1.0:
     dependencies:
       boxen: 5.1.2
@@ -30689,11 +30559,11 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.14.0
+      qs: 6.15.2
 
   use-deep-compare-effect@1.8.1(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.10
       dequal: 2.0.3
       react: 18.2.0
 
@@ -31225,43 +31095,47 @@ snapshots:
 
   wait-on@6.0.0(debug@4.3.2):
     dependencies:
-      axios: 0.21.4(debug@4.3.2)
+      axios: 1.17.0(debug@4.3.2)
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   wait-on@7.2.0:
     dependencies:
-      axios: 1.8.4(debug@4.3.2)
+      axios: 1.17.0
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   wait-on@7.2.0(debug@4.3.2):
     dependencies:
-      axios: 1.8.4(debug@4.3.2)
+      axios: 1.17.0(debug@4.3.2)
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   wait-on@7.2.0(debug@4.3.4):
     dependencies:
-      axios: 1.8.4(debug@4.3.4)
+      axios: 1.17.0(debug@4.3.4)
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   walk-up-path@1.0.0: {}
 
@@ -31357,7 +31231,7 @@ snapshots:
       express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.7(@types/express@4.17.21)(debug@4.3.2)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.3.2)
       ipaddr.js: 2.2.0
       open: 8.4.2
       p-retry: 4.6.2
@@ -31633,11 +31507,11 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yallist@2.1.2: {}
-
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml-eslint-parser@1.3.0:
     dependencies:

--- a/frontend/scripts/add_addons.sh
+++ b/frontend/scripts/add_addons.sh
@@ -17,18 +17,43 @@ echo "add_addons.sh: registering addons in volto.config.js"
 echo "$ADD_ADDONS" | tr ',' '\n' | while IFS= read -r addon; do
     addon="$(echo "$addon" | xargs)"  # trim whitespace
     [ -z "$addon" ] && continue
-    echo "  + $addon"
-    node -e "
+    export _ADDON_NAME="$addon"
+    node << 'NODEEOF'
 const fs = require('fs');
-const addon = '${addon}';
+
+const addon = process.env._ADDON_NAME;
 let content = fs.readFileSync('volto.config.js', 'utf8');
-content = content.replace(/(const addons = \[[\s\S]*?)(\n\];)/, (match, body, closing) => {
-    const trimmed = body.trimEnd();
-    const needsComma = !trimmed.endsWith(',');
-    return trimmed + (needsComma ? ',' : '') + \"\n  '\" + addon + \"'\" + closing;
-});
+
+const addonsPattern = /(const addons = \[)([\s\S]*?)(\n\];)/m;
+const match = content.match(addonsPattern);
+if (!match) {
+  console.error('add_addons.sh: could not find addons array in volto.config.js');
+  process.exit(1);
+}
+
+const [, opening, body, closing] = match;
+const addons = [];
+const seen = new Set();
+const existingAddonPattern = /(['"])([^'"\n]+)\1/g;
+let existingMatch;
+while ((existingMatch = existingAddonPattern.exec(body)) !== null) {
+  const existingAddon = existingMatch[2].trim();
+  if (!existingAddon || seen.has(existingAddon)) continue;
+  seen.add(existingAddon);
+  addons.push(existingAddon);
+}
+
+if (seen.has(addon)) {
+  console.log(`  = ${addon} (already present)`);
+} else {
+  console.log(`  + ${addon}`);
+  addons.push(addon);
+}
+
+const normalizedBody = addons.length ? `\n  '${addons.join("',\n  '")}'` : '';
+content = content.replace(addonsPattern, `${opening}${normalizedBody}${closing}`);
 fs.writeFileSync('volto.config.js', content);
-"
+NODEEOF
 done
 
 node --check volto.config.js && echo "add_addons.sh: volto.config.js is valid."

--- a/frontend/scripts/add_packages.sh
+++ b/frontend/scripts/add_packages.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Injects extra npm packages into package.json dependencies before pnpm install.
 # Usage: add_packages.sh "@scope/pkg@1.0.0,another-pkg@2.0.0"
-# Packages must be comma-separated npm specifiers: name@version (or name alone for latest).
+# Packages must be comma-separated npm specifiers: name@version.
+# If a package name is provided without a version and it already exists in package.json,
+# its current pinned version is preserved.
 
 set -e
 
@@ -27,19 +29,40 @@ echo "$ADD_PACKAGES" | tr ',' '\n' | while IFS= read -r pkg; do
         version="${BASH_REMATCH[2]}"
     else
         name="$pkg"
-        version="*"
+        version=""
     fi
 
-    echo "  + ${name}@${version}"
-    python3 -c "
+    if [ -n "$version" ]; then
+        echo "  + ${name}@${version}"
+    else
+        echo "  + ${name} (no version provided)"
+    fi
+
+    export _PKG_NAME="$name"
+    export _PKG_VERSION="$version"
+    python3 << 'PYEOF'
 import json
+import os
+
+name = os.environ['_PKG_NAME']
+version = os.environ['_PKG_VERSION']
+
 with open('package.json') as f:
     data = json.load(f)
-data['dependencies']['${name}'] = '${version}'
+
+deps = data.setdefault('dependencies', {})
+if version:
+    deps[name] = version
+    print(f'    set {name} -> {version}')
+elif name in deps and deps[name]:
+    print(f'    keeping existing version for {name}: {deps[name]}')
+else:
+    deps[name] = '*'
+    print(f'    set {name} -> *')
+
 with open('package.json', 'w') as f:
     json.dump(data, f, indent=2)
-print('    package.json updated')
-"
+PYEOF
 done
 
 echo "add_packages.sh: done."


### PR DESCRIPTION
 feat: inject initial admin password via entrypoint + expand frontend customization surface
 Add sitebase-entrypoint.sh as the backend ENTRYPOINT

 Expand the Makefile/script customization surface for frontend builds:
 - FRONTEND_SET_THEME / SET_THEME — delegates to scripts/set_theme.sh
 - FRONTEND_ADD_PNPM_WORKSPACE / ADD_PNPM_WORKSPACE — delegates to
   scripts/add_pnpm_workspace.sh
 - frontend/Makefile now auto-loads ../.env via -include, so `make install`
   run directly from ./frontend picks up root .env values